### PR TITLE
Fix bug #1331, fix memory leaks, support Volts/div units, sort channels by type, do not show all read capabilities, parse SCPI commands

### DIFF
--- a/main.c
+++ b/main.c
@@ -78,6 +78,21 @@ int maybe_config_get(struct sr_dev_driver *driver,
 		const struct sr_dev_inst *sdi, struct sr_channel_group *cg,
 		uint32_t key, GVariant **gvar)
 {
+	if (sr_dev_config_capabilities_list(sdi, cg, key) & SR_CONF_GET_MASK)
+		return sr_config_get(driver, sdi, cg, key, gvar);
+
+	return SR_ERR_NA;
+}
+
+/*
+ * Same as maybe_config_get(), but strictly for capabilities that can
+ * be only read. Automatic Measurements for example, should not be
+ * normally listed, so they are skipped by this function.
+ */
+int maybe_config_get_and_show(struct sr_dev_driver *driver,
+		const struct sr_dev_inst *sdi, struct sr_channel_group *cg,
+		uint32_t key, GVariant **gvar)
+{
 	if (sr_dev_config_capabilities_list(sdi, cg, key) & SR_CONF_GET)
 		return sr_config_get(driver, sdi, cg, key, gvar);
 

--- a/parsers.c
+++ b/parsers.c
@@ -272,6 +272,7 @@ GHashTable *parse_generic_arg(const char *arg, gboolean sep_first)
 	GHashTable *hash;
 	int i;
 	char **elements, *e;
+	const struct sr_key_info *info;
 
 	if (!arg || !arg[0])
 		return NULL;
@@ -279,7 +280,14 @@ GHashTable *parse_generic_arg(const char *arg, gboolean sep_first)
 	i = 0;
 	hash = g_hash_table_new_full(g_str_hash, g_str_equal,
 			g_free, g_free);
-	elements = g_strsplit(arg, ":", 0);
+
+	/* In the SCPI command syntax the ":" character is reserved. */
+	info = sr_key_info_get(SR_KEY_CONFIG, SR_CONF_CUSTOM_CMD);
+	if (info && !strncmp(info->id, arg, strlen(info->id))) {
+		elements = g_strsplit(arg, "\n", 1);
+	} else {
+		elements = g_strsplit(arg, ":", 0);
+	}
 	if (sep_first)
 		g_hash_table_insert(hash, g_strdup("sigrok_key"),
 				g_strdup(elements[i++]));

--- a/show.c
+++ b/show.c
@@ -208,7 +208,26 @@ static gint sort_channels(gconstpointer a, gconstpointer b)
 {
 	const struct sr_channel *pa = a, *pb = b;
 
-	return pa->index - pb->index;
+	if (pa->type == pb->type)
+		return pa->index - pb->index;
+
+	/*
+	 * Sort analog channels before digital channels and
+	 * digital channels before special FFT channels.
+	 */
+	if (pa->type == SR_CHANNEL_ANALOG)
+		return -1;
+
+	if (pb->type == SR_CHANNEL_ANALOG)
+		return 1;
+
+	if (pa->type == SR_CHANNEL_LOGIC)
+		return -1;
+
+	if (pb->type == SR_CHANNEL_LOGIC)
+		return 1;
+
+	return 0;
 }
 
 static void print_dev_line(const struct sr_dev_inst *sdi)

--- a/show.c
+++ b/show.c
@@ -321,7 +321,8 @@ void show_dev_detail(void)
 	GVariant *gvar_dict, *gvar_list, *gvar;
 	gsize num_elements;
 	double dlow, dhigh, dcur_low, dcur_high;
-	const uint64_t *uint64, p = 0, q = 0, low = 0, high = 0;
+	const uint64_t *uint64;
+	uint64_t p = 0, q = 0, low = 0, high = 0;
 	uint64_t tmp_uint64, mask, cur_low, cur_high, cur_p, cur_q;
 	GArray *opts;
 	const int32_t *int32;

--- a/show.c
+++ b/show.c
@@ -247,7 +247,7 @@ static void print_dev_line(const struct sr_dev_inst *sdi)
 
 	s = g_string_sized_new(128);
 	g_string_assign(s, driver->name);
-	if (maybe_config_get(driver, sdi, NULL, SR_CONF_CONN, &gvar) == SR_OK) {
+	if (maybe_config_get_and_show(driver, sdi, NULL, SR_CONF_CONN, &gvar) == SR_OK) {
 		g_string_append(s, ":conn=");
 		g_string_append(s, g_variant_get_string(gvar, NULL));
 		g_variant_unref(gvar);
@@ -524,7 +524,7 @@ void show_dev_detail(void)
 		} else if (srci->datatype == SR_T_UINT64) {
 			printf("    %s: ", srci->id);
 			gvar = NULL;
-			if (maybe_config_get(driver, sdi, channel_group, key,
+			if (maybe_config_get_and_show(driver, sdi, channel_group, key,
 					&gvar) == SR_OK) {
 				tmp_uint64 = g_variant_get_uint64(gvar);
 				g_variant_unref(gvar);
@@ -552,7 +552,7 @@ void show_dev_detail(void)
 
 		} else if (srci->datatype == SR_T_STRING) {
 			printf("    %s: ", srci->id);
-			if (maybe_config_get(driver, sdi, channel_group, key,
+			if (maybe_config_get_and_show(driver, sdi, channel_group, key,
 					&gvar) == SR_OK) {
 				tmp_str = g_strdup(g_variant_get_string(gvar, NULL));
 				g_variant_unref(gvar);
@@ -591,7 +591,7 @@ void show_dev_detail(void)
 				continue;
 			}
 
-			if (maybe_config_get(driver, sdi, channel_group, key, &gvar) == SR_OK) {
+			if (maybe_config_get_and_show(driver, sdi, channel_group, key, &gvar) == SR_OK) {
 				g_variant_get(gvar, "(tt)", &cur_low, &cur_high);
 				g_variant_unref(gvar);
 			} else {
@@ -615,7 +615,7 @@ void show_dev_detail(void)
 
 		} else if (srci->datatype == SR_T_BOOL) {
 			printf("    %s: ", srci->id);
-			if (maybe_config_get(driver, sdi, channel_group, key,
+			if (maybe_config_get_and_show(driver, sdi, channel_group, key,
 					&gvar) == SR_OK) {
 				if (g_variant_get_boolean(gvar))
 					printf("on (current), off\n");
@@ -633,7 +633,7 @@ void show_dev_detail(void)
 				continue;
 			}
 
-			if (maybe_config_get(driver, sdi, channel_group, key, &gvar) == SR_OK) {
+			if (maybe_config_get_and_show(driver, sdi, channel_group, key, &gvar) == SR_OK) {
 				g_variant_get(gvar, "(dd)", &dcur_low, &dcur_high);
 				g_variant_unref(gvar);
 			} else {
@@ -657,7 +657,7 @@ void show_dev_detail(void)
 
 		} else if (srci->datatype == SR_T_FLOAT) {
 			printf("    %s: ", srci->id);
-			if (maybe_config_get(driver, sdi, channel_group, key,
+			if (maybe_config_get_and_show(driver, sdi, channel_group, key,
 					&gvar) == SR_OK) {
 				printf("%f\n", g_variant_get_double(gvar));
 				g_variant_unref(gvar);
@@ -668,7 +668,7 @@ void show_dev_detail(void)
 				|| srci->datatype == SR_T_RATIONAL_VOLT
 				|| srci->datatype == SR_T_RATIONAL_VOLT_PER_DIV) {
 			printf("    %s", srci->id);
-			if (maybe_config_get(driver, sdi, channel_group, key,
+			if (maybe_config_get_and_show(driver, sdi, channel_group, key,
 					&gvar) == SR_OK) {
 				g_variant_get(gvar, "(tt)", &cur_p, &cur_q);
 				g_variant_unref(gvar);
@@ -704,7 +704,7 @@ void show_dev_detail(void)
 
 		} else if (srci->datatype == SR_T_MQ) {
 			printf("    %s: ", srci->id);
-			if (maybe_config_get(driver, sdi, channel_group, key,
+			if (maybe_config_get_and_show(driver, sdi, channel_group, key,
 					&gvar) == SR_OK
 					&& g_variant_is_of_type(gvar, G_VARIANT_TYPE_TUPLE)
 					&& g_variant_n_children(gvar) == 2) {

--- a/show.c
+++ b/show.c
@@ -646,7 +646,8 @@ void show_dev_detail(void)
 				printf("\n");
 
 		} else if (srci->datatype == SR_T_RATIONAL_PERIOD
-				|| srci->datatype == SR_T_RATIONAL_VOLT) {
+				|| srci->datatype == SR_T_RATIONAL_VOLT
+				|| srci->datatype == SR_T_RATIONAL_VOLT_PER_DIV) {
 			printf("    %s", srci->id);
 			if (maybe_config_get(driver, sdi, channel_group, key,
 					&gvar) == SR_OK) {
@@ -668,8 +669,12 @@ void show_dev_detail(void)
 				g_variant_unref(gvar);
 				if (srci->datatype == SR_T_RATIONAL_PERIOD)
 					s = sr_period_string(p, q);
-				else
+				else if (srci->datatype == SR_T_RATIONAL_VOLT)
 					s = sr_voltage_string(p, q);
+				else if (srci->datatype == SR_T_RATIONAL_VOLT_PER_DIV)
+					s = sr_voltage_per_div_string(p, q);
+				else
+					s = g_strdup("Invalid datatype");
 				printf("      %s", s);
 				g_free(s);
 				if (p == cur_p && q == cur_q)

--- a/show.c
+++ b/show.c
@@ -665,6 +665,7 @@ void show_dev_detail(void)
 			for (i = 0; i < num_elements; i++) {
 				gvar = g_variant_get_child_value(gvar_list, i);
 				g_variant_get(gvar, "(tt)", &p, &q);
+				g_variant_unref(gvar);
 				if (srci->datatype == SR_T_RATIONAL_PERIOD)
 					s = sr_period_string(p, q);
 				else
@@ -699,6 +700,7 @@ void show_dev_detail(void)
 				printf("      ");
 				gvar = g_variant_get_child_value(gvar_list, i);
 				g_variant_get(gvar, "(ut)", &mq, &mqflags);
+				g_variant_unref(gvar);
 				if ((srmqi = sr_key_info_get(SR_KEY_MQ, mq)))
 					printf("%s", srmqi->id);
 				else

--- a/sigrok-cli.h
+++ b/sigrok-cli.h
@@ -35,6 +35,9 @@ int select_channels(struct sr_dev_inst *sdi);
 int maybe_config_get(struct sr_dev_driver *driver,
 		const struct sr_dev_inst *sdi, struct sr_channel_group *cg,
 		uint32_t key, GVariant **gvar);
+int maybe_config_get_and_show(struct sr_dev_driver *driver,
+		const struct sr_dev_inst *sdi, struct sr_channel_group *cg,
+		uint32_t key, GVariant **gvar);
 int maybe_config_set(struct sr_dev_driver *driver,
 		const struct sr_dev_inst *sdi, struct sr_channel_group *cg,
 		uint32_t key, GVariant *gvar);


### PR DESCRIPTION
- Fix configuration option listing (timebase, vdiv, spl_meas_range) [bug #1331]
- Fix a couple of memory leaks
- Support printing Volts per division (V/div) units (used for the vertical scale)
 REQUIRES: 
https://github.com/sigrokproject/libsigrok/pull/17/commits/fc685341b2a32708f9e098e57a51d6bde894c6f6?
- Sort channels by type and not only by index
- Do not show all capabilities that can be read
  REQUIRES: 
https://github.com/sigrokproject/libsigrok/pull/17/commits/13c7144e7b4fb7d15134356fdc3f865cde41aa13?
- Support parsing SCPI commands
  REQUIRES: 
https://github.com/sigrokproject/libsigrok/pull/17/commits/9da062f4483fc444d0b6882b7054238803c20629?

 main.c       |   15 +++++++++++++++
 parsers.c    |   10 +++++++++-
 show.c       |   53 ++++++++++++++++++++++++++++++++++++++++-------------
 sigrok-cli.h |    3 +++
 4 files changed, 67 insertions(+), 14 deletions(-)