### PR TITLE
sigrok-cli: Add Google Trace Event output format (json)

### DIFF
--- a/main.c
+++ b/main.c
@@ -216,6 +216,9 @@ int main(int argc, char **argv)
 		return 1;
 	}
 
+	if(opt_pd_jsontrace)
+		printf("{\"traceEvents\": [\n");
+
 	/* Set the loglevel (amount of messages to output) for libsigrok. */
 	if (sr_log_loglevel_set(opt_loglevel) != SR_OK)
 		goto done;
@@ -299,6 +302,9 @@ int main(int argc, char **argv)
 done:
 	if (sr_ctx)
 		sr_exit(sr_ctx);
+
+	if(opt_pd_jsontrace)
+		printf("\n]}\n");
 
 	return 0;
 }

--- a/options.c
+++ b/options.c
@@ -39,6 +39,7 @@ gchar *opt_pd_annotations = NULL;
 gchar *opt_pd_meta = NULL;
 gchar *opt_pd_binary = NULL;
 gboolean opt_pd_samplenum = FALSE;
+gboolean opt_pd_jsontrace = FALSE;
 #endif
 gchar *opt_input_format = NULL;
 gchar *opt_output_format = NULL;
@@ -137,6 +138,8 @@ static const GOptionEntry optargs[] = {
 			"Protocol decoder binary output to show", NULL},
 	{"protocol-decoder-samplenum", 0, 0, G_OPTION_ARG_NONE, &opt_pd_samplenum,
 			"Show sample numbers in decoder output", NULL},
+	{"protocol-decoder-jsontrace", 0, 0, G_OPTION_ARG_NONE, &opt_pd_jsontrace,
+			"Output in Google JSON trace format", NULL},
 #endif
 	{"scan", 0, 0, G_OPTION_ARG_NONE, &opt_scan_devs,
 			"Scan for devices", NULL},

--- a/sigrok-cli.h
+++ b/sigrok-cli.h
@@ -111,6 +111,7 @@ extern gchar *opt_pd_annotations;
 extern gchar *opt_pd_meta;
 extern gchar *opt_pd_binary;
 extern gboolean opt_pd_samplenum;
+extern gboolean opt_pd_jsontrace;
 #endif
 extern gchar *opt_input_format;
 extern gchar *opt_output_format;


### PR DESCRIPTION

[example-output.zip](https://github.com/sigrokproject/sigrok-cli/files/2720849/example-output.zip)
The Chrome browser has a handy event viewer. It accepts JSON files
in the Google Trace Event format and views them in a similar way
to PulseView. The format is a convenient way to share decoded logic
captures. Note that being text based, the filesizes are large, though
Chrome does accept them zipped.

The patch adds a flag which switches the decoder output format:

--protocol-decoder-jsontrace

And an alternative output in show_pd_annotations which formats the
samples appropriately.

An example command line might be:

 sigrok-cli -P i2c:scl=D0:sda=D1 -P i2c:scl=D2:sda=D3 -i test.sr --protocol-decoder-jsontrace > test.json

This would take test.sr, decode two sets of I2C traffic and output as
JSON. Browsing to chrome://tracing from within Chrome, this json file
can then be loaded and viewed.

The patch is currently hard coded to 1MHz samplerate, I'm not
familiar enough with the sigrok code to figure out how to access
the samplerate from show_pd_annotations.

To show the output, I've attached example-output.zip which can be loaded straight into chrome://tracing.