### PR TITLE
Set stdout to binary mode on Windows as needed

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -30,6 +30,7 @@ sigrok_cli_SOURCES = \
 	device.c \
 	session.c \
 	input.c \
+	output.c \
 	decode.c \
 	sigrok-cli.h \
 	parsers.c \

--- a/main.c
+++ b/main.c
@@ -242,6 +242,8 @@ int main(int argc, char **argv)
 		if (opt_pd_binary) {
 			if (setup_pd_binary(opt_pd_binary) != 0)
 				goto done;
+			if (setup_binary_stdout() != 0)
+				goto done;
 			if (srd_pd_output_callback_add(srd_sess, SRD_OUTPUT_BINARY,
 					show_pd_binary, NULL) != SRD_OK)
 				goto done;

--- a/output.c
+++ b/output.c
@@ -1,0 +1,42 @@
+/*
+ * This file is part of the sigrok-cli project.
+ *
+ * Copyright (C) 2019 Devan Lai <devan.lai@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdio.h>
+
+#ifdef _WIN32
+#include <io.h>
+#include <fcntl.h>
+#endif
+
+#include <glib.h>
+#include "sigrok-cli.h"
+
+/* Disable newline translation on stdout when outputting binary data
+ */
+int setup_binary_stdout(void)
+{
+#ifdef _WIN32
+	int oldmode = _setmode(_fileno(stdout), _O_BINARY);
+	if (oldmode == -1) {
+		g_critical("Failed to set binary stdout mode: errno=%d", errno);
+		return -1;
+	}
+#endif
+	return 0;
+}

--- a/session.c
+++ b/session.c
@@ -117,6 +117,7 @@ const struct sr_output *setup_output_format(const struct sr_dev_inst *sdi, FILE 
 			*outfile = NULL;
 		}
 	} else {
+		setup_binary_stdout();
 		*outfile = stdout;
 	}
 

--- a/sigrok-cli.h
+++ b/sigrok-cli.h
@@ -82,6 +82,9 @@ void run_session(void);
 /* input.c */
 void load_input_file(gboolean do_props);
 
+/* output.c */
+int setup_binary_stdout(void);
+
 /* decode.c */
 #ifdef HAVE_SRD
 int register_pds(gchar **all_pds, char *opt_pd_annotations);


### PR DESCRIPTION
On Windows, stdout defaults to text mode, which attempts to perform newline conversion such that if it sees a bare line feed (hex 0A), it will insert a carriage return (hex 0D) before the line feed.

For textual output like normal annotation display or ascii art, this is desirable, but for binary output, this is likely to garble the output.

On Windows when using stdout as the output file destination or when using `-B`/`--protocol-decoder-binary` option, change the mode of stdout to `_O_BINARY` to disable this newline conversion to ensure that the binary output is faithfully delivered to stdout without modifications.

On all other platforms, `setup_binary_stdout()` is a no-op.

For binary protocol decoder output, this change makes non-text-based output usable on Windows, whereas before it was often unusable. For output formats that support writing to stdout (e.g. not `srzip`), this makes the output written to stdout consistent with the output written directly to a file.

Note that for some text-based output formats that are meant to be read by humans like `ascii`, `analog`, `bits`, and `hex`, this change is a step backwards, as those formats will no longer have correct line-endings on Windows when output to stdout.

To handle those cases, I have another set of changes split across [libsigrok](https://github.com/devanlai/libsigrok/commit/e21b631f8bfa316e8ca743a6648f1fe6798e943a) and [sigrok-cli](https://github.com/devanlai/sigrok-cli/commit/a4e6704574f18174011e3a83f4376dadd81ea810)/[pulseview](https://github.com/devanlai/pulseview/commit/f31aff8b06204ff29f78076c85527a8bf27d7e5d) to add an output module flag indicating the output is text-based, which the front-end can then use to select between text mode and binary mode as needed.