### PR TITLE
Allow both global and cg options on command line.

### DIFF
--- a/doc/sigrok-cli.1
+++ b/doc/sigrok-cli.1
@@ -201,7 +201,7 @@ to the right override previous items. For example
 will set the name of channel 1 to
 .BR "MISO" .
 .TP
-.BR "\-g, \-\-channel\-group "<channel\ group>
+.BR "\-g, \-\-channel\-group "<channel\ group>[:setting=value]
 Specify the channel group to operate on. Some devices organize channels into
 groups, the settings of which can only be changed as a group. The list of
 channel groups, if any, is displayed with the \fB\-\-show\fP command.
@@ -210,7 +210,7 @@ Examples:
 .sp
 .RB "  $ " "sigrok\-cli \-g CH1" " [...]"
 .sp
-.RB "  $ " "sigrok\-cli \-d demo \-g Logic \-c pattern=graycode" " [...]"
+.RB "  $ " "sigrok\-cli \-d demo \-g Logic:pattern=graycode" " [...]"
 .TP
 .BR "\-t, \-\-triggers " <triggerlist>
 A comma-separated list of triggers to use, of the form

--- a/main.c
+++ b/main.c
@@ -78,8 +78,8 @@ int maybe_config_get(struct sr_dev_driver *driver,
 		const struct sr_dev_inst *sdi, struct sr_channel_group *cg,
 		uint32_t key, GVariant **gvar)
 {
-	if (sr_dev_config_capabilities_list(sdi, NULL, key) & SR_CONF_GET)
-		return sr_config_get(driver, sdi, NULL, key, gvar);
+	if (sr_dev_config_capabilities_list(sdi, cg, key) & SR_CONF_GET)
+		return sr_config_get(driver, sdi, cg, key, gvar);
 
 	return SR_ERR_NA;
 }
@@ -90,8 +90,8 @@ int maybe_config_set(struct sr_dev_driver *driver,
 {
 	(void)driver;
 
-	if (sr_dev_config_capabilities_list(sdi, NULL, key) & SR_CONF_SET)
-		return sr_config_set(sdi, NULL, key, gvar);
+	if (sr_dev_config_capabilities_list(sdi, cg, key) & SR_CONF_SET)
+		return sr_config_set(sdi, cg, key, gvar);
 
 	return SR_ERR_NA;
 }
@@ -100,8 +100,8 @@ int maybe_config_list(struct sr_dev_driver *driver,
 		const struct sr_dev_inst *sdi, struct sr_channel_group *cg,
 		uint32_t key, GVariant **gvar)
 {
-	if (sr_dev_config_capabilities_list(sdi, NULL, key) & SR_CONF_LIST)
-		return sr_config_list(driver, sdi, NULL, key, gvar);
+	if (sr_dev_config_capabilities_list(sdi, cg, key) & SR_CONF_LIST)
+		return sr_config_list(driver, sdi, cg, key, gvar);
 
 	return SR_ERR_NA;
 }
@@ -141,7 +141,7 @@ static void get_option(void)
 		g_critical("Unknown option '%s'", opt_get);
 
 	if ((devargs = parse_generic_arg(opt_config, FALSE)))
-		set_dev_options(sdi, devargs, cg);
+		set_dev_options(sdi, devargs, NULL);
 	else
 		devargs = NULL;
 
@@ -201,7 +201,7 @@ static void set_options(void)
 		return;
 	}
 
-	set_dev_options(sdi, devargs, select_channel_group(sdi));
+	set_dev_options(sdi, devargs, NULL);
 
 	sr_dev_close(sdi);
 	g_hash_table_destroy(devargs);

--- a/main.c
+++ b/main.c
@@ -78,8 +78,8 @@ int maybe_config_get(struct sr_dev_driver *driver,
 		const struct sr_dev_inst *sdi, struct sr_channel_group *cg,
 		uint32_t key, GVariant **gvar)
 {
-	if (sr_dev_config_capabilities_list(sdi, cg, key) & SR_CONF_GET)
-		return sr_config_get(driver, sdi, cg, key, gvar);
+	if (sr_dev_config_capabilities_list(sdi, NULL, key) & SR_CONF_GET)
+		return sr_config_get(driver, sdi, NULL, key, gvar);
 
 	return SR_ERR_NA;
 }
@@ -90,8 +90,8 @@ int maybe_config_set(struct sr_dev_driver *driver,
 {
 	(void)driver;
 
-	if (sr_dev_config_capabilities_list(sdi, cg, key) & SR_CONF_SET)
-		return sr_config_set(sdi, cg, key, gvar);
+	if (sr_dev_config_capabilities_list(sdi, NULL, key) & SR_CONF_SET)
+		return sr_config_set(sdi, NULL, key, gvar);
 
 	return SR_ERR_NA;
 }
@@ -100,8 +100,8 @@ int maybe_config_list(struct sr_dev_driver *driver,
 		const struct sr_dev_inst *sdi, struct sr_channel_group *cg,
 		uint32_t key, GVariant **gvar)
 {
-	if (sr_dev_config_capabilities_list(sdi, cg, key) & SR_CONF_LIST)
-		return sr_config_list(driver, sdi, cg, key, gvar);
+	if (sr_dev_config_capabilities_list(sdi, NULL, key) & SR_CONF_LIST)
+		return sr_config_list(driver, sdi, NULL, key, gvar);
 
 	return SR_ERR_NA;
 }
@@ -141,7 +141,7 @@ static void get_option(void)
 		g_critical("Unknown option '%s'", opt_get);
 
 	if ((devargs = parse_generic_arg(opt_config, FALSE)))
-		set_dev_options(sdi, devargs);
+		set_dev_options(sdi, devargs, cg);
 	else
 		devargs = NULL;
 
@@ -201,7 +201,7 @@ static void set_options(void)
 		return;
 	}
 
-	set_dev_options(sdi, devargs);
+	set_dev_options(sdi, devargs, select_channel_group(sdi));
 
 	sr_dev_close(sdi);
 	g_hash_table_destroy(devargs);

--- a/options.c
+++ b/options.c
@@ -33,7 +33,7 @@ gchar *opt_output_file = NULL;
 gchar *opt_drv = NULL;
 gchar *opt_config = NULL;
 gchar *opt_channels = NULL;
-gchar *opt_channel_group = NULL;
+gchar **opt_channel_groups = NULL;
 gchar *opt_triggers = NULL;
 gchar **opt_pds = NULL;
 #ifdef HAVE_SRD
@@ -83,7 +83,6 @@ CHECK_ONCE(opt_input_format)
 CHECK_ONCE(opt_output_format)
 CHECK_ONCE(opt_transform_module)
 CHECK_ONCE(opt_channels)
-CHECK_ONCE(opt_channel_group)
 CHECK_ONCE(opt_triggers)
 #ifdef HAVE_SRD
 CHECK_ONCE(opt_pd_annotations)
@@ -125,7 +124,7 @@ static const GOptionEntry optargs[] = {
 			"Transform module", NULL},
 	{"channels", 'C', 0, G_OPTION_ARG_CALLBACK, &check_opt_channels,
 			"Channels to use", NULL},
-	{"channel-group", 'g', 0, G_OPTION_ARG_CALLBACK, &check_opt_channel_group,
+	{"channel-group", 'g', 0, G_OPTION_ARG_STRING_ARRAY, &opt_channel_groups,
 			"Channel groups", NULL},
 	{"triggers", 't', 0, G_OPTION_ARG_CALLBACK, &check_opt_triggers,
 			"Trigger configuration", NULL},

--- a/session.c
+++ b/session.c
@@ -648,6 +648,8 @@ int opt_to_gvar(char *key, char *value, struct sr_config *src)
 	return ret;
 }
 
+/* Set options: device global options if cg is NULL,
+ * channel group options if not */
 int set_dev_options(struct sr_dev_inst *sdi, GHashTable *args,
 		struct sr_channel_group *cg)
 {

--- a/sigrok-cli.h
+++ b/sigrok-cli.h
@@ -76,7 +76,8 @@ struct df_arg_desc {
 void datafeed_in(const struct sr_dev_inst *sdi,
 		const struct sr_datafeed_packet *packet, void *cb_data);
 int opt_to_gvar(char *key, char *value, struct sr_config *src);
-int set_dev_options(struct sr_dev_inst *sdi, GHashTable *args);
+int set_dev_options(struct sr_dev_inst *sdi, GHashTable *args,
+		struct sr_channel_group *cg);
 void run_session(void);
 
 /* input.c */
@@ -124,7 +125,7 @@ extern gchar *opt_output_file;
 extern gchar *opt_drv;
 extern gchar *opt_config;
 extern gchar *opt_channels;
-extern gchar *opt_channel_group;
+extern gchar **opt_channel_groups;
 extern gchar *opt_triggers;
 extern gchar **opt_pds;
 #ifdef HAVE_SRD


### PR DESCRIPTION
Example case: in hantek-6xxx samplerate is a global option, vdiv is a channelgroup option.
```
$ sigrok-cli -d hantek-6xxx  -C CH1 --config vdiv=1V:samplerate=1m --samples=1 
Failed to set device option 'vdiv': not applicable.
$ sigrok-cli -d hantek-6xxx  -g CH1 --config vdiv=1V:samplerate=1m --samples=1 
Failed to set device option 'samplerate': not applicable.
```

~With this fix, the latter example above works.~