### PR TITLE
Various changes to improve parsing of the "--channels" option

### DIFF
--- a/doc/sigrok-cli.1
+++ b/doc/sigrok-cli.1
@@ -201,13 +201,15 @@ The default is to use all the channels available on a device. You can name
 a channel like this:
 .BR "1=CLK" .
 A range of channels can also be given, in the form
-.BR "1\-5" .
+.BR "1\-5"
+or (if they have a common prefix)
+.BR "CH1\-5" .
 .sp
 Example:
 .sp
 .RB "  $ " "sigrok\-cli \-\-driver fx2lafw \-\-samples 100"
 .br
-.B "               \-\-channels 1=CLK,2\-4,7"
+.B "               \-\-channels D1=CLK,D2\-4,D7"
 .br
  CLK:11111111 11111111 11111111 11111111 [...]
    2:11111111 11111111 11111111 11111111 [...]

--- a/parsers.c
+++ b/parsers.c
@@ -74,13 +74,6 @@ GSList *parse_channelstring(struct sr_dev_inst *sdi, const char *channelstring)
 		}
 
 		names = g_strsplit(tokens[i], "=", 2);
-		if (!names[0] || (names[1] && names[2])) {
-			/* Need one or two arguments. */
-			g_critical("Invalid channel '%s'.", tokens[i]);
-			g_strfreev(names);
-			ret = SR_ERR;
-			break;
-		}
 
 		/* Check first if a channel with the given name already exists, as it
 		 * might contain a dash from a rename in an earlier option.
@@ -107,12 +100,6 @@ GSList *parse_channelstring(struct sr_dev_inst *sdi, const char *channelstring)
 			}
 
 			range = g_strsplit(names[0], "-", 2);
-			if (!range[0] || !range[1] || range[2]) {
-				/* Need exactly two arguments. */
-				g_critical("Invalid channel syntax '%s'.", tokens[i]);
-				ret = SR_ERR;
-				goto range_fail;
-			}
 
 			/* Find start of numeric range (first digit) in range string. */
 			for (sptr = names[0]; *sptr != '-' && !isdigit(*sptr); sptr++);

--- a/parsers.c
+++ b/parsers.c
@@ -18,6 +18,7 @@
  */
 
 #include <config.h>
+#include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
@@ -51,8 +52,8 @@ GSList *parse_channelstring(struct sr_dev_inst *sdi, const char *channelstring)
 {
 	struct sr_channel *ch;
 	GSList *channellist, *channels;
-	int ret, n, b, e, i;
-	char **tokens, **range, **names, *eptr, str[8];
+	int ret, n, b, e, i, plen;
+	char **tokens, **range, **names, *sptr, *eptr, str[8];
 
 	channels = sr_dev_inst_channels_get(sdi);
 
@@ -94,9 +95,9 @@ GSList *parse_channelstring(struct sr_dev_inst *sdi, const char *channelstring)
 		} else if (strchr(names[0], '-')) {
 			/*
 			 * A range of channels in the form a-b. This will only work
-			 * if the channels are named as numbers -- so every channel
-			 * in the range must exist as a channel name string in the
-			 * device.
+			 * if the channels are named as numbers (with an optional prefix)
+			 * -- so every channel in the range must exist as a channel name
+			 * string in the device.
 			 */
 			if (names[1]) {
 				/* Channel range syntax not allowed when renaming. */
@@ -113,15 +114,28 @@ GSList *parse_channelstring(struct sr_dev_inst *sdi, const char *channelstring)
 				goto range_fail;
 			}
 
+			/* Find start of numeric range (first digit) in range string. */
+			for (sptr = names[0]; *sptr != '-' && !isdigit(*sptr); sptr++);
+			if (*sptr == '-') { /* no digit found before range separator. */
+				g_critical("Channel range '%s' needs numbered channels.", names[0]);
+				ret = SR_ERR;
+				goto range_fail;
+			}
+
+			/* Length of channel name prefix. */
+			plen = sptr - names[0];
+
+			range = g_strsplit(sptr, "-", 2);
+
 			b = strtol(range[0], &eptr, 10);
 			if (eptr == range[0] || *eptr != '\0') {
-				g_critical("Invalid channel '%s'.", range[0]);
+				g_critical("Invalid channel '%.*s%s'.", plen, names[0], range[0]);
 				ret = SR_ERR;
 				goto range_fail;
 			}
 			e = strtol(range[1], NULL, 10);
 			if (eptr == range[1] || *eptr != '\0') {
-				g_critical("Invalid channel '%s'.", range[1]);
+				g_critical("Invalid channel '%.*s%s'.", plen, names[0], range[1]);
 				ret = SR_ERR;
 				goto range_fail;
 			}
@@ -132,15 +146,15 @@ GSList *parse_channelstring(struct sr_dev_inst *sdi, const char *channelstring)
 			}
 
 			while (b <= e) {
-				n = snprintf(str, 8, "%d", b);
+				n = snprintf(str, 8, "%.*s%d", plen, names[0], b);
 				if (n < 0 || n > 8) {
-					g_critical("Invalid channel '%d'.", b);
+					g_critical("Invalid channel '%.*s%d'.", plen, names[0], b);
 					ret = SR_ERR;
 					break;
 				}
 				ch = find_channel(channels, str, TRUE);
 				if (!ch) {
-					g_critical("unknown channel '%d'.", b);
+					g_critical("unknown channel '%s'.", str);
 					ret = SR_ERR;
 					break;
 				}


### PR DESCRIPTION
1. Right now, it isn't possible to rename a channel to anything that includes a dash ("-") character, as the parsing code then tries to handle the option as a channel range, which it is not. This makes it impossible to for example correctly name a usb data "D-" signal. So check if the option string contains an equals character (for a channel rename) first.

2. As it is, the whole "channel range" feature isn't very useful, as it only works for purely numeric channel names and most (all?) drivers seem to name their channels with a common, non-numeric prefix (like D0, D1, ...). So allow a common prefix in a channel range.

3. The third patch isn't strictly necessary, it only removes two checks that I consider useless but right now don't do any harm (that could change as one of the checks seems to rely on undocumented glib behaviour, see the commit message).