### PR TITLE
decode: Optionally print timestamp with PD annotations

### DIFF
--- a/decode.c
+++ b/decode.c
@@ -628,7 +628,7 @@ void show_pd_annotations(struct srd_proto_data *pdata, void *cb_data)
 	GSList *ann_list, *l;
 	int i;
 	char **ann_descr;
-	gboolean show_ann, show_snum, show_class, show_quotes, show_abbrev;
+	gboolean show_ann, show_tstamp, show_snum, show_class, show_quotes, show_abbrev;
 	const char *quote;
 
 	(void)cb_data;
@@ -673,7 +673,10 @@ void show_pd_annotations(struct srd_proto_data *pdata, void *cb_data)
 	 * - Optionally put quote marks around annotation text, when
 	 *   recipients might have to deal with a set of text variants.
 	 */
-	show_snum = show_class = show_quotes = show_abbrev = FALSE;
+	show_tstamp = show_snum = show_class = show_quotes = show_abbrev = FALSE;
+	if (opt_pd_timestamp) {
+		show_tstamp = TRUE;
+	}
 	if (opt_pd_samplenum || opt_loglevel > SR_LOG_WARN) {
 		show_snum = TRUE;
 	}
@@ -692,6 +695,11 @@ void show_pd_annotations(struct srd_proto_data *pdata, void *cb_data)
 	if (show_snum) {
 		printf("%" PRIu64 "-%" PRIu64 " ",
 			pdata->start_sample, pdata->end_sample);
+	}
+	if (show_tstamp && pd_samplerate) {
+		double ts_sec = pdata->start_sample;
+		ts_sec /= pd_samplerate;
+		printf("%9.3lf ", ts_sec);
 	}
 	printf("%s: ", pdata->pdo->proto_id);
 	if (show_class) {

--- a/doc/sigrok-cli.1
+++ b/doc/sigrok-cli.1
@@ -422,6 +422,10 @@ binary class you're interested in)
 .sp
 Not every decoder generates binary output.
 .TP
+.BR "\-\-protocol\-decoder\-timestamp
+When given, decoder annotations will include start sample timestamps.
+This allows consumers to receive human readable timing information.
+.TP
 .BR "\-\-protocol\-decoder\-samplenum
 When given, decoder annotations will include sample numbers, too.
 This allows consumers to receive machine readable timing information.

--- a/options.c
+++ b/options.c
@@ -40,6 +40,7 @@ gchar **opt_pds = NULL;
 gchar *opt_pd_annotations = NULL;
 gchar *opt_pd_meta = NULL;
 gchar *opt_pd_binary = NULL;
+gboolean opt_pd_timestamp = FALSE;
 gboolean opt_pd_samplenum = FALSE;
 gboolean opt_pd_jsontrace = FALSE;
 #endif
@@ -139,6 +140,8 @@ static const GOptionEntry optargs[] = {
 			"Protocol decoder meta output to show", NULL},
 	{"protocol-decoder-binary", 'B', 0, G_OPTION_ARG_CALLBACK, &check_opt_pd_binary,
 			"Protocol decoder binary output to show", NULL},
+	{"protocol-decoder-timestamp", 0, 0, G_OPTION_ARG_NONE, &opt_pd_timestamp,
+			"Show timestamp in decoder output", NULL},
 	{"protocol-decoder-samplenum", 0, 0, G_OPTION_ARG_NONE, &opt_pd_samplenum,
 			"Show sample numbers in decoder output", NULL},
 	{"protocol-decoder-jsontrace", 0, 0, G_OPTION_ARG_NONE, &opt_pd_jsontrace,

--- a/sigrok-cli.h
+++ b/sigrok-cli.h
@@ -140,6 +140,7 @@ extern gchar **opt_pds;
 extern gchar *opt_pd_annotations;
 extern gchar *opt_pd_meta;
 extern gchar *opt_pd_binary;
+extern gboolean opt_pd_timestamp;
 extern gboolean opt_pd_samplenum;
 extern gboolean opt_pd_jsontrace;
 #endif


### PR DESCRIPTION
Introduce the "--protocol-decoder-timestamp" command line option (no
short form available), which emits timestamp with textual output
from protocol decoder annotations, regardless of a log level value.

This shall increase usability of sigrok-cli output to make it more
human readable. The option exclusively adds timestamps to the
output but does not affect the presence or layout of any other line.

This commit prepends "text" and "meta" annotations with timestamp
information. It does not change "binary" output.

It is not intended to accurately determine the time to within nanoseconds
(there is option "--protocol-decoder-samplenum" for it) but for logging
continuous processes and for quick understanding what happened
without having to calculate the time over samplenums.

Example of use:
```
$ sigrok-cli -d fx2lafw -c samplerate=1M --continuous \
             -P i2c:scl=D2:sda=D3,i2c_packet:transaction=yes \
             -A i2c_packet --protocol-decoder-timestamp
   0.070 i2c_packet-1: 0x08 WR: 04 [SR] 0x08 RD: 05 02 00 3C 15 00 00 0A 00 01 00 00 00 00 00 00 00 00 00 00 00 00 00 01 00 FF FF B7
   0.169 i2c_packet-1: 0x08 WR: 04 [SR] 0x08 RD: 05 02 00 3C 15 00 00 0A 00 01 00 00 00 00 00 00 00 00 00 00 00 00 00 01 00 FF FF B7
   0.268 i2c_packet-1: 0x08 WR: 04 [SR] 0x08 RD: 05 02 00 3C 15 00 00 0A 00 01 00 00 00 00 00 00 00 00 00 00 00 00 00 01 00 FF FF B7
```