### PR TITLE
decode: Optionally print annotation class with PD annotations

### DIFF
--- a/decode.c
+++ b/decode.c
@@ -684,6 +684,8 @@ void show_pd_annotations(struct srd_proto_data *pdata, void *cb_data)
 		show_class = TRUE;
 		show_abbrev = TRUE;
 	}
+	if (opt_pd_ann_class)
+		show_class = TRUE;
 
 	/*
 	 * Display the annotation's fields after the layout was

--- a/doc/sigrok-cli.1
+++ b/doc/sigrok-cli.1
@@ -426,6 +426,9 @@ Not every decoder generates binary output.
 When given, decoder annotations will include sample numbers, too.
 This allows consumers to receive machine readable timing information.
 .TP
+.BR "\-\-protocol\-decoder\-ann\-class
+When given, decoder annotations will include annotation class names.
+.TP
 .BR "\-l, \-\-loglevel " <level>
 Set the libsigrok and libsigrokdecode loglevel. At the moment \fBsigrok\-cli\fP
 doesn't support setting the two loglevels independently. The higher the

--- a/options.c
+++ b/options.c
@@ -40,6 +40,7 @@ gchar **opt_pds = NULL;
 gchar *opt_pd_annotations = NULL;
 gchar *opt_pd_meta = NULL;
 gchar *opt_pd_binary = NULL;
+gboolean opt_pd_ann_class = FALSE;
 gboolean opt_pd_samplenum = FALSE;
 gboolean opt_pd_jsontrace = FALSE;
 #endif
@@ -139,6 +140,8 @@ static const GOptionEntry optargs[] = {
 			"Protocol decoder meta output to show", NULL},
 	{"protocol-decoder-binary", 'B', 0, G_OPTION_ARG_CALLBACK, &check_opt_pd_binary,
 			"Protocol decoder binary output to show", NULL},
+	{"protocol-decoder-ann-class", 0, 0, G_OPTION_ARG_NONE, &opt_pd_ann_class,
+			"Show annotation class in decoder output", NULL},
 	{"protocol-decoder-samplenum", 0, 0, G_OPTION_ARG_NONE, &opt_pd_samplenum,
 			"Show sample numbers in decoder output", NULL},
 	{"protocol-decoder-jsontrace", 0, 0, G_OPTION_ARG_NONE, &opt_pd_jsontrace,

--- a/sigrok-cli.h
+++ b/sigrok-cli.h
@@ -140,6 +140,7 @@ extern gchar **opt_pds;
 extern gchar *opt_pd_annotations;
 extern gchar *opt_pd_meta;
 extern gchar *opt_pd_binary;
+extern gboolean opt_pd_ann_class;
 extern gboolean opt_pd_samplenum;
 extern gboolean opt_pd_jsontrace;
 #endif


### PR DESCRIPTION
Introduce the "--protocol-decoder-ann-class" command line option
(no short form available).

Based on commit 08e9378bf68a by @gsigh 

There is a problem with sigrok-cli output when some decoders output similar
data with different annotation classes. For example:
```
uart-1: DA 03 00 02 01 0C D6                  
uart-1: AD 0C 80 00 00 00 00 00 00 00 00 00 FE
```
The first one has the class "tx-packet" and the other has the class "rx-packet".

The only way to print the class names is to use loglevel > 3  now. But then a lot of
unnecessary data is printed in the output and therefore filtering is needed.

This patch emits annotation class names with textual output from protocol decoder
annotations, regardless of a log level value. Example of resulting output:
```
uart-1: tx-packet: DA 03 00 02 01 0C D6
uart-1: rx-packet: AD 0C 80 00 00 00 00 00 00 00 00 00 00 00 00 21
```